### PR TITLE
nppPluginManager: Update version, projectUrl. and releaseNotes URL

### DIFF
--- a/notepadplusplus-nppPluginManager/notepadplusplus-nppPluginManager.nuspec
+++ b/notepadplusplus-nppPluginManager/notepadplusplus-nppPluginManager.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>notepadplusplus-npppluginmanager</id>
     <title>nppPluginManager</title>
-    <version>1.14.1</version>
+    <version>1.4.11</version>
     <authors>Dave Brotherstone</authors>
     <owners>Mao</owners>
     <copyright>Copyright (C) 2011-2018 Dave Brotherstone</copyright>
@@ -29,11 +29,11 @@ Features
     </description>
     <docsUrl>https://rawgit.com/bruderstein/nppPluginManager/master/doc/index.html</docsUrl>
     <iconUrl>https://rawgit.com/turboBasic/au-packages/master/notepadplusplus-nppPluginManager/icon.png</iconUrl>
-    <projectUrl>https://bruderste.in/npp/pm</projectUrl>
+    <projectUrl>https://rawgit.com/bruderstein/nppPluginManager/master/doc/index.html</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <packageSourceUrl>https://github.com/turboBasic/au-packages/tree/master/notepadplusplus-nppPluginManager</packageSourceUrl>
     <projectSourceUrl>https://github.com/bruderstein/nppPluginManager</projectSourceUrl>
-    <releaseNotes>https://bruderste.in/npp/pm/#changes</releaseNotes>
+    <releaseNotes>https://rawgit.com/bruderstein/nppPluginManager/master/doc/index.html#changes</releaseNotes>
     <summary>npp Plugin Manager is plugin which allows you to install, update and remove plugins from Notepad++</summary>
     <tags>text editor windows freeware development</tags>
     <dependencies>


### PR DESCRIPTION
The version incorrectly shows 1.14.1 in the manifest, but the actual version is 1.4.11.  
The URL's are pointing to an outdated website last updated for npp Plugin Manager v1.4.9. The rawgit.com site appears to be up to date.